### PR TITLE
Fix: Stops transforming body in json if content type is xml.

### DIFF
--- a/lib/eezee/client/requester.rb
+++ b/lib/eezee/client/requester.rb
@@ -74,7 +74,11 @@ module Eezee
         return unless req.payload
 
         faraday_req.body = req.payload
-        faraday_req.body = faraday_req.body.to_json unless req.url_encoded
+
+        return if req.url_encoded
+        return if req.headers[:"Content-Type"] == 'application/xml'
+
+        faraday_req.body = faraday_req.body.to_json
       end
 
       def build_faraday_client(request)


### PR DESCRIPTION
Evita que o payload seja transformado em json se o content-type for xml.

Pensei em colocar pra aplicar pra todo caso onde o content-type não é json, mas não sei se as outras aplicações que usam essa lib sempre setam o content-type, então preferi deixar assim pra evitar quebrar outras aplicações.