### PR TITLE
chore: revamp faraday-retry middleware setup

### DIFF
--- a/spec/eezee/request_spec.rb
+++ b/spec/eezee/request_spec.rb
@@ -124,7 +124,21 @@ RSpec.describe Eezee::Request, type: :model do
         url_encoded: false,
         preserve_url_params: false,
         ddtrace: {},
-        max_retries: 2
+        retry_opts: {
+          exceptions: [
+            Errno::ETIMEDOUT,
+            'Timeout::Error',
+            Faraday::TimeoutError,
+            Faraday::RetriableResponse,
+            Errno::ECONNRESET,
+            Faraday::ConflictError,
+            Faraday::ConnectionFailed
+          ],
+          interval: 0.5,
+          max: 2,
+          methods: %i[delete get head options put],
+          retry_statuses: [409, 429]
+        }
       )
     end
   end

--- a/spec/support/shared/eezee/client/builder.rb
+++ b/spec/support/shared/eezee/client/builder.rb
@@ -67,7 +67,8 @@ shared_examples_for :eezee_client_builder do |builder|
                                raise_error: true,
                                url: 'www.linqueta.com',
                                protocol: 'https',
-                               headers: { 'Content-Type' => 'application/json' }
+                               headers: { 'Content-Type' => 'application/json' },
+                               max_retries: 10
           end
         end
 


### PR DESCRIPTION
Conseguir passar mais parâmetros do _middleware_ do `faraday-retry`  para o Eezee via config.