### PR TITLE
fix(logger): filter sensitive headers before logging

### DIFF
--- a/lib/eezee/logger.rb
+++ b/lib/eezee/logger.rb
@@ -2,6 +2,8 @@
 
 module Eezee
   module Logger
+    SENSITIVE_HEADERS = %w[Authorization Ocp-Apim-Subscription-Key].freeze
+
     module_function
 
     def request(req, method)
@@ -23,7 +25,7 @@ module Eezee
           type: 'request',
           method: method,
           uri: content.uri,
-          headers: content.headers,
+          headers: filter_headers(content.headers),
           payload: content.payload
         }.compact
 
@@ -41,6 +43,14 @@ module Eezee
       }.compact
 
       p log_hash.to_json
+    end
+
+    def filter_headers(headers)
+      return headers unless headers.is_a?(Hash)
+
+      headers.to_h do |key, value|
+        SENSITIVE_HEADERS.any? { |s| s.casecmp(key.to_s).zero? } ? [key, '[FILTERED]'] : [key, value]
+      end
     end
   end
 end

--- a/lib/eezee/version.rb
+++ b/lib/eezee/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Eezee
-  VERSION = '1.0.17'
+  VERSION = '1.0.18'
 end

--- a/spec/eezee/logger_spec.rb
+++ b/spec/eezee/logger_spec.rb
@@ -29,6 +29,32 @@ RSpec.describe Eezee::Logger, type: :model do
     end
   end
 
+  describe '.filter_headers' do
+    it 'masks Authorization header' do
+      result = described_class.filter_headers({ 'Authorization' => 'Bearer secret' })
+      expect(result).to eq({ 'Authorization' => '[FILTERED]' })
+    end
+
+    it 'masks Ocp-Apim-Subscription-Key header' do
+      result = described_class.filter_headers({ 'Ocp-Apim-Subscription-Key' => 'abc123' })
+      expect(result).to eq({ 'Ocp-Apim-Subscription-Key' => '[FILTERED]' })
+    end
+
+    it 'preserves non-sensitive headers' do
+      result = described_class.filter_headers({ 'Content-Type' => 'application/json' })
+      expect(result).to eq({ 'Content-Type' => 'application/json' })
+    end
+
+    it 'is case-insensitive for header names' do
+      result = described_class.filter_headers({ 'authorization' => 'Bearer secret' })
+      expect(result).to eq({ 'authorization' => '[FILTERED]' })
+    end
+
+    it 'returns non-hash input unchanged' do
+      expect(described_class.filter_headers(nil)).to be_nil
+    end
+  end
+
   describe '.response' do
     subject { Eezee::Logger.response(response) }
 


### PR DESCRIPTION
## Contexto

Headers sensíveis (`Authorization`, `Ocp-Apim-Subscription-Key`) estavam sendo logados em plaintext via stdout, ficando visíveis no GCP Cloud Logging.

## O que muda

- Adiciona constante `SENSITIVE_HEADERS` em `Eezee::Logger`
- Adiciona método `filter_headers` que substitui valores sensíveis por `[FILTERED]` antes de montar o hash de log
- Matching case-insensitive para os nomes dos headers
- Bump de versão: `1.0.17` → `1.0.18`

## Plano de testes

- [ ] `bundle exec rspec spec/eezee/logger_spec.rb` — specs existentes passam + novos casos cobrem filtragem
- [ ] Verificar que headers não-sensíveis (`Content-Type`, `Token`) continuam aparecendo nos logs normalmente
- [ ] Verificar que `Authorization` e `Ocp-Apim-Subscription-Key` aparecem como `[FILTERED]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)